### PR TITLE
Do not require a SSH key to clone CodeQL submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "codeql"]
 	path = codeql
-	url = git@github.com:github/codeql.git
+	url = https://github.com/github/codeql.git
 	branch = lgtm.com


### PR DESCRIPTION
Hello,

When cloning this repository, `git` prompted for a SSH key because it tried to clone https://github.com/github/codeql using SSH. As CodeQL's repository is public, HTTPS can be used instead.

This enables performing the workshop in a temporary virtual machine which is not linked to any GitHub account.